### PR TITLE
Update cdn-cache-invalidator.php

### DIFF
--- a/cdn-cache-invalidator.php
+++ b/cdn-cache-invalidator.php
@@ -147,9 +147,9 @@ function cdn_cache_invalidator_clear() {
   }
 
   $access_key = get_option('cdn_cache_invalidator_access_key');
-  if (!$access_key) wp_die(__('This plugin is not configured yet'));
+  //if (!$access_key) wp_die(__('This plugin is not configured yet'));
   $access_secret = get_option('cdn_cache_invalidator_access_secret');
-  if (!$access_secret) wp_die(__('This plugin is not configured yet'));
+  //if (!$access_secret) wp_die(__('This plugin is not configured yet'));
   $distribution = get_option('cdn_cache_invalidator_distribution');
   if (!$distribution) wp_die(__('This plugin is not configured yet'));
   $domain = get_option('cdn_cache_invalidator_domain');


### PR DESCRIPTION
Should not die if Access Key and/or Secret does not exit, in case of an EC2 instance using an instance profile.